### PR TITLE
update 1.0.6 release notes to reference rivine for details

### DIFF
--- a/doc/release_notes/v1.0.5_patch.md
+++ b/doc/release_notes/v1.0.5_patch.md
@@ -1,0 +1,12 @@
+# Releasenotes TFchain v1.0.5 Atomic Swaps Patch
+
+This release is a patched version of the v1.0.5 release.
+The main motivation for this patch was to ensure that our atomic swap feature
+works without bugs, and that all atomic swap CLI commands are aligned with
+the decred tools, with exceptions where logic is specific to Rivine.
+
+As this is a patch, there is no tag that accompanies it,
+you'll however find it on GitHub as <https://github.com/threefoldfoundation/tfchain/tree/v1.0.5-patch>.
+
+> See the rivine release notes for more notes as well as upgrade concerns:
+> <https://github.com/rivine/rivine/blob/master/doc/release_notes/v1.0.5_patch.md>

--- a/doc/release_notes/v1.0.6.md
+++ b/doc/release_notes/v1.0.6.md
@@ -1,5 +1,10 @@
 # Releasenotes Threefold chain v1.0.6
 
+If you apply this update directly from release v1.0.5,
+than please also take into account the changes that were already released with the patched version of v1.0.5.
+
+You can find the release notes for `v1.0.5-patch` at: [/doc/release_notes/v1.0.5_patch.md](/doc/release_notes/v1.0.5_patch.md).
+
 ## Summary
 
 - TODO: add web explorer stuff;

--- a/doc/release_notes/v1.0.6.md
+++ b/doc/release_notes/v1.0.6.md
@@ -1,5 +1,8 @@
 # Releasenotes Threefold chain v1.0.6
 
-## Upgrade concerns
+## Summary
 
--   the `--legacy` and `--locktime` flags have been removed from the wallet send commands as well as the fact that the REST `POST /wallet/coin` and `POST /wallet/blockstakes` no longer take a version as argument. If your technology does still give a version argument, not to worry, it will simply be ignored, and `version: 1` will be used instead, as should have been your choice already anyhow.
+- TODO: add web explorer stuff;
+
+> See the rivine release notes for more notes as well as upgrade concerns:
+> <https://github.com/rivine/rivine/blob/master/doc/release_notes/v1.0.6.md>


### PR DESCRIPTION
Relies on https://github.com/rivine/rivine/pull/362 being merged.