### PR TITLE
ensure multisig cannot be used on standardnet before block 42000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jobs:
       script:
         - make
         - make ineffassign
+        - make test
     - stage: test
       language: go
       go: 1.9.x
@@ -16,6 +17,7 @@ jobs:
       script:
         - make
         - make ineffassign
+        - make test
     - stage: test
       language: go
       go: 1.10.x
@@ -24,11 +26,4 @@ jobs:
       script:
         - make
         - make ineffassign
-    - stage: test
-      language: go
-      go: tip
-      install:
-        - go get -u github.com/gordonklaus/ineffassign
-      script:
-        - make
-        - make ineffassign
+        - make test

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -98,7 +98,7 @@
     "sync",
     "types"
   ]
-  revision = "f9374e5e8082d7068ebba091cf82e4f1f76c32d7"
+  revision = "940e316ea621b67150ade3f82b75eecc63824b20"
 
 [[projects]]
   name = "github.com/rivine/smux"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: install
 daemonpkgs = ./cmd/tfchaind
 clientpkgs = ./cmd/tfchainc
 pkgs = $(daemonpkgs) $(clientpkgs)
+testpkgs = $(daemonpkgs)
 
 version = $(shell git describe | cut -d '-' -f 1)
 commit = $(shell git rev-parse --short HEAD)
@@ -28,6 +29,9 @@ install:
 install-std:
 	go build -ldflags '$(ldflagsversion)' -o $(daemonbin) $(daemonpkgs)
 	go build -ldflags '$(ldflagsversion)' -o $(clientbin) $(clientpkgs)
+
+test:
+	go test -race -v -tags='debug testing' -timeout=60s $(testpkgs)
 
 # xc builds and packages release binaries
 # for all windows, linux and mac, 64-bit only,

--- a/cmd/tfchaind/main.go
+++ b/cmd/tfchaind/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/threefoldfoundation/tfchain/pkg/config"
 
 	"github.com/rivine/rivine/pkg/daemon"
+	"github.com/rivine/rivine/types"
 )
 
 var (
@@ -26,6 +27,12 @@ func main() {
 
 // SetupNetworks injects the correct chain constants and genesis nodes based on the chosen network
 func SetupNetworks(name string) (daemon.NetworkConfig, error) {
+	// configure any tfchain-specific logic related to how
+	// unlock conditions/fulfillments are to be interpreted/used.
+	ConfigureUnlockConditions(name)
+
+	// return the network configuration, based on the network name,
+	// which includes the genesis block as well as the bootstrap peers
 	switch name {
 	case standardnet:
 		return daemon.NetworkConfig{
@@ -46,4 +53,54 @@ func SetupNetworks(name string) (daemon.NetworkConfig, error) {
 	default:
 		return daemon.NetworkConfig{}, fmt.Errorf("Netork name %q not recognized", name)
 	}
+}
+
+// ConfigureUnlockConditions configures the unlock conditions,
+// as to define the unlock conditions and fulfillments.
+// For the most parts the configuration follows the standard Rivine unlock condition configuration,
+// but there are a couple of differences:
+//
+// * if the networkName equals "standard",
+//   the MultiSignatureCondition is only considered standard since block height 42000,
+//   giving peers on the standard network more or less 7 days, since 1.0.6 was released
+func ConfigureUnlockConditions(networkName string) {
+	if networkName != standardnet {
+		return // only apply the blockheight-based restrictions for standard net
+	}
+	// Overwrite the Rivine-standard MultiSignatureCondition with our wrapped version,
+	// as to ensure that this condition is only introduced in the
+	// standard tfchain since blockheight 42000
+	overwriteMultiSignatureConditionType()
+	// MultiSignatureFulfillment doesn't need to be overriden,
+	// as it is impossible to use it as long as there isn't an unspend output
+	// which uses the MultiSignatureCondition
+}
+
+func overwriteMultiSignatureConditionType() {
+	types.RegisterUnlockConditionType(types.ConditionTypeMultiSignature,
+		func() types.MarshalableUnlockCondition { return new(MultiSignatureCondition) })
+}
+
+// MultiSignatureCondition wraps around the Rivine-standard MultiSignatureCondition type,
+// as to ensure that in the standard network of tfchain, it can only be used since blockheight 42000
+type MultiSignatureCondition struct {
+	*types.MultiSignatureCondition
+}
+
+const (
+	// MinimumBlockHeightForMultiSignatureConditions defines the blockheight
+	// since when MultiSignatureConditions are considered standard on the tfchain standard network.
+	MinimumBlockHeightForMultiSignatureConditions = types.BlockHeight(42000)
+)
+
+// IsStandardCondition implements UnlockCondition.IsStandardCondition,
+// wrapping around the internal MultiSignatureCondition's IsStandardCondition check,
+// adding a pre-check of the blockheight
+func (msc MultiSignatureCondition) IsStandardCondition(ctx types.StandardCheckContext) error {
+	if ctx.BlockHeight < MinimumBlockHeightForMultiSignatureConditions {
+		return fmt.Errorf(
+			"multisignature conditions are only allowed since blockheight %d",
+			MinimumBlockHeightForMultiSignatureConditions)
+	}
+	return msc.MultiSignatureCondition.IsStandardCondition(ctx)
 }

--- a/cmd/tfchaind/main.go
+++ b/cmd/tfchaind/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/threefoldfoundation/tfchain/pkg/config"
 
 	"github.com/rivine/rivine/pkg/daemon"
-	"github.com/rivine/rivine/types"
 )
 
 var (
@@ -20,87 +19,45 @@ func main() {
 	defaultDaemonConfig.BlockchainInfo = config.GetBlockchainInfo()
 	// Default network name, testnet for now since real network is not live yet
 	defaultDaemonConfig.NetworkName = standardnet
-	defaultDaemonConfig.CreateNetworConfig = SetupNetworks
+	defaultDaemonConfig.CreateNetworkConfig = SetupNetworksAndTypes
 
 	daemon.SetupDefaultDaemon(defaultDaemonConfig)
 }
 
-// SetupNetworks injects the correct chain constants and genesis nodes based on the chosen network
-func SetupNetworks(name string) (daemon.NetworkConfig, error) {
-	// configure any tfchain-specific logic related to how
-	// unlock conditions/fulfillments are to be interpreted/used.
-	ConfigureUnlockConditions(name)
-
+// SetupNetworksAndTypes injects the correct chain constants and genesis nodes based on the chosen network,
+// it also ensures that features added during the lifetime of the blockchain,
+// only get activated on a certain block height, giving everyone sufficient time to upgrade should such features be introduced.
+func SetupNetworksAndTypes(name string) (daemon.NetworkConfig, error) {
 	// return the network configuration, based on the network name,
 	// which includes the genesis block as well as the bootstrap peers
 	switch name {
 	case standardnet:
+		// Forbid the usage of MultiSignatureCondition (and thus the multisig feature),
+		// until the blockchain reached a height of 42000 blocks.
+		RegisteredBlockHeightLimitedMultiSignatureCondition()
+
+		// return the standard genesis block and bootstrap peers
 		return daemon.NetworkConfig{
 			Constants:      config.GetStandardnetGenesis(),
 			BootstrapPeers: config.GetStandardnetBootstrapPeers(),
 		}, nil
+
 	case testnet:
+		// return the testnet genesis block and bootstrap peers
 		return daemon.NetworkConfig{
 			Constants:      config.GetTestnetGenesis(),
 			BootstrapPeers: config.GetTestnetBootstrapPeers(),
 		}, nil
+
 	case devnet:
+		// return the devnet genesis block and bootstrap peers
 		return daemon.NetworkConfig{
 			Constants:      config.GetDevnetGenesis(),
 			BootstrapPeers: nil,
 		}, nil
 
 	default:
+		// network isn't recognised
 		return daemon.NetworkConfig{}, fmt.Errorf("Netork name %q not recognized", name)
 	}
-}
-
-// ConfigureUnlockConditions configures the unlock conditions,
-// as to define the unlock conditions and fulfillments.
-// For the most parts the configuration follows the standard Rivine unlock condition configuration,
-// but there are a couple of differences:
-//
-// * if the networkName equals "standard",
-//   the MultiSignatureCondition is only considered standard since block height 42000,
-//   giving peers on the standard network more or less 7 days, since 1.0.6 was released
-func ConfigureUnlockConditions(networkName string) {
-	if networkName != standardnet {
-		return // only apply the blockheight-based restrictions for standard net
-	}
-	// Overwrite the Rivine-standard MultiSignatureCondition with our wrapped version,
-	// as to ensure that this condition is only introduced in the
-	// standard tfchain since blockheight 42000
-	overwriteMultiSignatureConditionType()
-	// MultiSignatureFulfillment doesn't need to be overriden,
-	// as it is impossible to use it as long as there isn't an unspend output
-	// which uses the MultiSignatureCondition
-}
-
-func overwriteMultiSignatureConditionType() {
-	types.RegisterUnlockConditionType(types.ConditionTypeMultiSignature,
-		func() types.MarshalableUnlockCondition { return new(MultiSignatureCondition) })
-}
-
-// MultiSignatureCondition wraps around the Rivine-standard MultiSignatureCondition type,
-// as to ensure that in the standard network of tfchain, it can only be used since blockheight 42000
-type MultiSignatureCondition struct {
-	*types.MultiSignatureCondition
-}
-
-const (
-	// MinimumBlockHeightForMultiSignatureConditions defines the blockheight
-	// since when MultiSignatureConditions are considered standard on the tfchain standard network.
-	MinimumBlockHeightForMultiSignatureConditions = types.BlockHeight(42000)
-)
-
-// IsStandardCondition implements UnlockCondition.IsStandardCondition,
-// wrapping around the internal MultiSignatureCondition's IsStandardCondition check,
-// adding a pre-check of the blockheight
-func (msc MultiSignatureCondition) IsStandardCondition(ctx types.StandardCheckContext) error {
-	if ctx.BlockHeight < MinimumBlockHeightForMultiSignatureConditions {
-		return fmt.Errorf(
-			"multisignature conditions are only allowed since blockheight %d",
-			MinimumBlockHeightForMultiSignatureConditions)
-	}
-	return msc.MultiSignatureCondition.IsStandardCondition(ctx)
 }

--- a/cmd/tfchaind/multisig.go
+++ b/cmd/tfchaind/multisig.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/rivine/rivine/types"
+)
+
+// RegisteredBlockHeightLimitedMultiSignatureCondition registers the multisig condition,
+// and thus implicitly the fulfillment as well, in a way that it is limited to a certain block height.
+func RegisteredBlockHeightLimitedMultiSignatureCondition() {
+	types.RegisterUnlockConditionType(types.ConditionTypeMultiSignature,
+		func() types.MarshalableUnlockCondition { return new(MultiSignatureCondition) })
+}
+
+// MultiSignatureCondition wraps around the Rivine-standard MultiSignatureCondition type,
+// as to ensure that in the standard network of tfchain, it can only be used since blockheight 42000
+type MultiSignatureCondition struct {
+	*types.MultiSignatureCondition
+}
+
+const (
+	// MinimumBlockHeightForMultiSignatureConditions defines the blockheight
+	// since when MultiSignatureConditions are considered standard on the tfchain standard network.
+	MinimumBlockHeightForMultiSignatureConditions = types.BlockHeight(42000)
+)
+
+// IsStandardCondition implements UnlockCondition.IsStandardCondition,
+// wrapping around the internal MultiSignatureCondition's IsStandardCondition check,
+// adding a pre-check of the blockheight
+func (msc MultiSignatureCondition) IsStandardCondition(ctx types.StandardCheckContext) error {
+	if ctx.BlockHeight < MinimumBlockHeightForMultiSignatureConditions {
+		return fmt.Errorf(
+			"multisignature conditions are only allowed since blockheight %d",
+			MinimumBlockHeightForMultiSignatureConditions)
+	}
+	return msc.MultiSignatureCondition.IsStandardCondition(ctx)
+}

--- a/cmd/tfchaind/multisig_standard_test.go
+++ b/cmd/tfchaind/multisig_standard_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rivine/rivine/types"
+)
+
+func TestMultiSignatureConditionIsStandardCondition(t *testing.T) {
+	ctx := types.StandardCheckContext{}
+	// create the condition manually
+	msc := MultiSignatureCondition{
+		MultiSignatureCondition: &types.MultiSignatureCondition{
+			UnlockHashes: []types.UnlockHash{
+				unlockHashFromHex("01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893"),
+				unlockHashFromHex("01c46a8e1e7f1bb0e3b7ec6c93b9c4f3e5d89e855f5a57f22d478d72d6233391153fac7d179087"),
+			},
+			MinimumSignatureCount: 1,
+		},
+	}
+	// ensure that the internal condition's standard check does pass
+	err := msc.MultiSignatureCondition.IsStandardCondition(ctx)
+	if err != nil {
+		t.Fatal("expected standard condition check pass, but it failed: ", err)
+	}
+	// ensure that our internal condition's standard check fails
+	err = msc.IsStandardCondition(ctx)
+	if err == nil {
+		t.Fatal("expected standard condition check to fail, but it didn't")
+	}
+}
+
+func TestRegisteredMultiSignatureCondition(t *testing.T) {
+	// temporary overwrite multisig condition type, just for this unit test
+	overwriteMultiSignatureConditionType()
+	defer types.RegisterUnlockConditionType(types.ConditionTypeMultiSignature,
+		func() types.MarshalableUnlockCondition { return new(types.MultiSignatureCondition) })
+
+	const jsonCondition = `{
+	"type": 4,
+	"data": {
+		"unlockhashes": [
+			"01746677df456546d93729066dd88514e2009930f3eebac3c93d43c88a108f8f9aa9e7c6f58893",
+			"01c46a8e1e7f1bb0e3b7ec6c93b9c4f3e5d89e855f5a57f22d478d72d6233391153fac7d179087"
+		],
+		"minimumsignaturecount": 2
+	}
+}`
+
+	// decode our json-encoded multisig condition
+	var condition types.UnlockConditionProxy
+	err := condition.UnmarshalJSON([]byte(jsonCondition))
+	if err != nil {
+		t.Fatal("failed to decode multisignature condition into proxy condition: ", err)
+	}
+
+	// ensure the condition type is MultiSig
+	if ct := condition.ConditionType(); ct != types.ConditionTypeMultiSignature {
+		t.Fatalf("expected condition type to be %d, but it was %d instead",
+			types.ConditionTypeMultiSignature, ct)
+	}
+
+	// sanity check, ensure it is our type
+	if _, ok := condition.Condition.(*MultiSignatureCondition); !ok {
+		t.Fatalf("expected condition type to be (our) *MultiSignatureCondition, but it was %T instead",
+			condition.Condition)
+	}
+
+	// ensure that it can't be used yet at height 0
+	ctx := types.StandardCheckContext{}
+	err = condition.IsStandardCondition(ctx)
+	if err == nil {
+		t.Fatal("expected standard condition check to fail, but it didn't")
+	}
+
+	// ensure that it can be used at the minimum height
+	ctx.BlockHeight = MinimumBlockHeightForMultiSignatureConditions
+	err = condition.IsStandardCondition(ctx)
+	if err != nil {
+		t.Fatal("expected standard condition check pass, but it failed: ", err)
+	}
+}
+
+func unlockHashFromHex(hstr string) (uh types.UnlockHash) {
+	err := uh.LoadString(hstr)
+	if err != nil {
+		panic(fmt.Sprintf("func unlockHashFromHex(%s) failed: %v", hstr, err))
+	}
+	return
+}

--- a/cmd/tfchaind/multisig_test.go
+++ b/cmd/tfchaind/multisig_test.go
@@ -33,7 +33,7 @@ func TestMultiSignatureConditionIsStandardCondition(t *testing.T) {
 
 func TestRegisteredMultiSignatureCondition(t *testing.T) {
 	// temporary overwrite multisig condition type, just for this unit test
-	overwriteMultiSignatureConditionType()
+	RegisteredBlockHeightLimitedMultiSignatureCondition()
 	defer types.RegisterUnlockConditionType(types.ConditionTypeMultiSignature,
 		func() types.MarshalableUnlockCondition { return new(types.MultiSignatureCondition) })
 

--- a/vendor/github.com/rivine/rivine/pkg/daemon/daemon.go
+++ b/vendor/github.com/rivine/rivine/pkg/daemon/daemon.go
@@ -72,8 +72,10 @@ type Config struct {
 	// optional network config constructor,
 	// if you're implementing your own rivine-based blockchain,
 	// you'll probably want to define this one,
-	// as otherwise a pure rivine blockchain config will be created
-	CreateNetworConfig func(name string) (NetworkConfig, error)
+	// as otherwise a pure rivine blockchain config will be created,
+	// within this function you should also Register any specific
+	// transaction, conditions and fulfillments
+	CreateNetworkConfig func(name string) (NetworkConfig, error)
 }
 
 // DefaultConfig returns the default daemon configuration
@@ -105,9 +107,9 @@ func (cfg *Config) createConfiguredNetworkConfig() (NetworkConfig, error) {
 		// default to build.Release as network name
 		cfg.NetworkName = build.Release
 	}
-	if cfg.CreateNetworConfig != nil {
+	if cfg.CreateNetworkConfig != nil {
 		// use custom network config creator
-		return cfg.CreateNetworConfig(cfg.NetworkName)
+		return cfg.CreateNetworkConfig(cfg.NetworkName)
 	}
 
 	// use default network config creator


### PR DESCRIPTION
This means that the multisig feature won't be able to be used prior to +/- Next week Saturday (09/06) night, or 6 days (+/-) after the release of 1.0.6.

Doing so gives peers on the standard (tfchain) network, a bit more time to upgrade, rather than risking to stop syncing (as a fork shouldn't be possible, given that we're sure all block creator nodes will upgrade) as soon as the release.