### PR TITLE
provide full multisig support in web explorer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -98,7 +98,7 @@
     "sync",
     "types"
   ]
-  revision = "dbb0d244ccfcdb55ad2a9f1f40e584728299a113"
+  revision = "4b3322be8160243ba17833b455fc27fa56fd551d"
 
 [[projects]]
   name = "github.com/rivine/smux"


### PR DESCRIPTION
also add code to make block stake outputs work with v1 transactions,
as it seemed there wasn't any code for that available

closes #146 

**NOTE**: we should first review+merge https://github.com/rivine/rivine/pull/409, so that we can properly vendor the updated Rivine code, rather than manually updating it directly in the vendor dir.