### PR TITLE
improve shell/docker/make build/release pipeline

### DIFF
--- a/DockerBuilderEdgeNoEth
+++ b/DockerBuilderEdgeNoEth
@@ -1,9 +1,0 @@
-FROM golang:1.11
-MAINTAINER threefoldfoundation
-
-ENV CGO_ENABLED 0
-WORKDIR /go/src/github.com/threefoldfoundation/tfchain
-
-RUN apt-get update && apt-get install -y zip
-
-ENTRYPOINT ./release_noeth.sh edge

--- a/DockerBuilderNoEth
+++ b/DockerBuilderNoEth
@@ -6,4 +6,5 @@ WORKDIR /go/src/github.com/threefoldfoundation/tfchain
 
 RUN apt-get update && apt-get install -y zip
 
-ENTRYPOINT ./release_noeth.sh
+ENTRYPOINT ["./release_noeth.sh"]
+CMD []

--- a/DockerfileMinimal
+++ b/DockerfileMinimal
@@ -4,6 +4,7 @@ ARG binaries_location=dist/linux
 
 COPY $binaries_location/tfchaind /tfchaind
 COPY $binaries_location/tfchainc /tfchainc
+COPY $binaries_location/bridged /bridged
 
 EXPOSE 23112
 

--- a/release_noeth.sh
+++ b/release_noeth.sh
@@ -12,6 +12,12 @@ else
 	full_version="${version}-${commit}"
 fi
 
+ARCHIVE=false
+if [ "$1" = "archive" ]; then
+	ARCHIVE=true
+	shift # remove element from arguments
+fi
+
 # Overide the file names to edge version, keep full version at the git commit since
 # that is the expected format
 if [ "$1" = "edge" ]; then
@@ -34,18 +40,20 @@ for os in darwin linux; do
 
 	done
 
-	# add other artifacts
-	cp -r doc LICENSE README.md "$folder"
-	# go into the release directory
-	pushd release &> /dev/null
-	# zip
-	(
-		zip -rq "tfchain-noeth-${version}-${os}-amd64.zip" \
-			"tfchain-noeth-${version}-${os}-amd64"
-	)
-	# leave the release directory
-	popd &> /dev/null
+	if [ "$ARCHIVE" = true ] ; then
+		# add other artifacts
+		cp -r doc LICENSE README.md "$folder"
+		# go into the release directory
+		pushd release &> /dev/null
+		# zip
+		(
+			zip -rq "tfchain-noeth-${version}-${os}-amd64.zip" \
+				"tfchain-noeth-${version}-${os}-amd64"
+		)
+		# leave the release directory
+		popd &> /dev/null
 
-	# clean up workspace dir
-	rm -rf "$folder"
+		# clean up workspace dir
+		rm -rf "$folder"
+	fi
 done


### PR DESCRIPTION
- have separate build/archive targets
- focus docker-minimal targets only on linux xc builds