### PR TITLE
No need to override the default coin granularity

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,11 @@ const (
 	TestNetworkBlockFrequency     types.BlockHeight = 120 // 1 block per 2 minutes on average
 )
 
+// GetCurrencyUnits returns the currency units used for all ThreeFold networks.
+func GetCurrencyUnits() types.CurrencyUnits {
+	return types.DefaultCurrencyUnits()
+}
+
 // GetBlockchainInfo returns the naming and versioning of tfchain.
 func GetBlockchainInfo() types.BlockchainInfo {
 	return types.BlockchainInfo{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,14 +38,6 @@ const (
 	TestNetworkBlockFrequency     types.BlockHeight = 120 // 1 block per 2 minutes on average
 )
 
-// GetCurrencyUnits returns the currency units used for all ThreeFold networks.
-func GetCurrencyUnits() types.CurrencyUnits {
-	return types.CurrencyUnits{
-		// 1 coin = 1 000 000 000 of the smalles possible units
-		OneCoin: types.NewCurrency(new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil)),
-	}
-}
-
 // GetBlockchainInfo returns the naming and versioning of tfchain.
 func GetBlockchainInfo() types.BlockchainInfo {
 	return types.BlockchainInfo{
@@ -69,9 +61,6 @@ func GetStandardnetGenesisMintCondition() types.UnlockConditionProxy {
 // GetStandardnetGenesis explicitly sets all the required constants for the genesis block of the standard (prod) net
 func GetStandardnetGenesis() types.ChainConstants {
 	cfg := types.StandardnetChainConstants()
-
-	// use the threefold currency units
-	cfg.CurrencyUnits = GetCurrencyUnits()
 
 	// set transaction versions
 	cfg.DefaultTransactionVersion = types.TransactionVersionOne
@@ -201,9 +190,6 @@ func GetTestnetGenesisMintCondition() types.UnlockConditionProxy {
 func GetTestnetGenesis() types.ChainConstants {
 	cfg := types.TestnetChainConstants()
 
-	// use the threefold currency units
-	cfg.CurrencyUnits = GetCurrencyUnits()
-
 	// set transaction versions
 	cfg.DefaultTransactionVersion = types.TransactionVersionOne
 	cfg.GenesisTransactionVersion = types.TransactionVersionZero
@@ -271,9 +257,6 @@ func GetDevnetGenesisMintCondition() types.UnlockConditionProxy {
 // GetDevnetGenesis explicitly sets all the required constants for the genesis block of the devnet
 func GetDevnetGenesis() types.ChainConstants {
 	cfg := types.DevnetChainConstants()
-
-	// use the threefold currency units
-	cfg.CurrencyUnits = GetCurrencyUnits()
 
 	// set transaction versions
 	cfg.DefaultTransactionVersion = types.TransactionVersionOne


### PR DESCRIPTION
just want to keep  it simple